### PR TITLE
CI: add codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,23 @@
+codecov:
+  require_ci_to_pass: false
+  notify:
+    require_ci_to_pass: no
+    after_n_builds: 1
+coverage:
+  status:
+    project:
+      default:
+        # Require 1% coverage, i.e., always succeed
+        target: 1
+    patch:
+      default:
+        # Must be 0%, because many PRs touch files that we don't have coverage
+        # results for (build files, scripts, tools/, etc.)
+        target: 0
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
+    changes: false
+comment: off
+github_checks:
+    annotations: false

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade numpy mypy cmake pytest pybind11 scikit-build patchelf
+          python -m pip install --upgrade numpy mypy cmake pytest pybind11 scikit-build patchelf pytest-cov codecov
       - name: Install pykokkos-base
         run: |
           cd /tmp
@@ -39,4 +39,8 @@ jobs:
           mypy pykokkos
       - name: run tests
         run: |
-          python runtests.py
+          python runtests.py --coverage
+      - name: codecov check
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: False

--- a/runtests.py
+++ b/runtests.py
@@ -20,12 +20,16 @@ pytest_args = []
 parser = argparse.ArgumentParser()
 parser.add_argument('-t', '--specifictests', type=str)
 parser.add_argument('-d', '--durations', type=int)
+parser.add_argument('-c', '--coverage', type=str)
 args = parser.parse_args()
 
 if args.specifictests:
     pytest_args.append(args.specifictests)
 if args.durations:
     pytest_args.append(f"--durations={args.durations}")
+if args.coverage:
+    pytest_args.append(f"--cov-report xml")
+
 
 # force pytest to actually import
 # all the test modules directly


### PR DESCRIPTION
* start reporting code line coverage in the CI with `codecov` (don't fail CI or add
annoying bot messages related to coverage though)